### PR TITLE
Colors array

### DIFF
--- a/server.js
+++ b/server.js
@@ -159,7 +159,18 @@ app.patch('/api/v1/palettes/:id', async (request, response) => {
       return response.status(404).json({ error: `Could not locate palette: ${id}` })
     }
     const updatedPalette = await database('palettes').where('id', id).update(patch, '*');
-    return response.status(200).json(updatedPalette);
+    const newPalette = updatedPalette.map(palette => {
+      const paletteKeys = Object.keys(palette);
+      return paletteKeys.reduce((acc, key) => {
+        if (key.includes('color')) {
+          acc.colors.push(palette[key]);
+        } else {
+          acc[key] = palette[key];
+        }
+        return acc;
+      }, { colors: [] })
+    });
+    return response.status(200).json(newPalette);
   } catch (error) {
     return response.status(500).json({ error });
   }

--- a/server.js
+++ b/server.js
@@ -52,7 +52,18 @@ app.get('/api/v1/projects/:id/palettes', async (request, response) => {
     if(!palettes.length) {
       return response.status(404).json({ error: `Project with ID of ${id} does not have any palettes` });
     }
-    return response.status(200).json(palettes);
+    const newPalettes = palettes.map(palette => {
+      const paletteKeys = Object.keys(palette);
+      return paletteKeys.reduce((acc, key) => {
+        if (key.includes('color')) {
+          acc.colors.push(palette[key]);
+        } else {
+          acc[key] = palette[key];
+        }
+        return acc;
+      }, { colors: [] })
+    });
+    return response.status(200).json(newPalettes);
   } catch (error) {
     return response.status(500).json({ error });
   }
@@ -65,12 +76,23 @@ app.get('/api/v1/palettes/:id', async (request, response) => {
     return response.status(422).json({ error: `Incorrect ID: ${id}, Required data type: <Number>`})
   }
 
-  try { 
+  try {
     const palette = await database('palettes').where('id', id).select();
     if(!palette.length) {
       return response.status(404).json({ error: `Could not locate palette: ${id}` });
     }
-    return response.status(200).json(palette);
+    const newPalette = palette.map(palette => {
+      const paletteKeys = Object.keys(palette);
+      return paletteKeys.reduce((acc, key) => {
+        if (key.includes('color')) {
+          acc.colors.push(palette[key]);
+        } else {
+          acc[key] = palette[key];
+        }
+        return acc;
+      }, { colors: [] })
+    });
+    return response.status(200).json(newPalette);
   } catch (error) {
     return response.status(500).json({ error });
   }


### PR DESCRIPTION
#### What does this PR do?
- Adds functionality to edit the palette object that is being queried from the database and then sent via the response body. The palette object comes back from the database containing a key/value pair for each of the five colors that make up the palette - resulting in 5 separate key/value pairs. With the end-user in mind (the FE developer) we thought it would be more useful for them to get this information in the form of an array turning those 5 key/value pairs into 1. The array will contain strings of the colors hex numbers in the same numerical order from that of the database. This way the user can easily use those hex codes by iterating through them to display, manipulate and edit.
- This functionality is reused three times, as we are returning palette objects on three different occassions: 
1. GET all palettes via project ID
2. GET a palette via palette ID
3. PATCH a palette by updating the colors 

#### How to test?
- Pull down `set-up-migrations` branch 
- Make sure you have the above tech installed
- Run server on localhost
- For now you can use Postman to test the endpoints and see the response in the new format.

```
{
        "colors": [
            "#28765",
            "#85463",
            "#98476",
            "#23534",
            "#98576"
        ],
        "id": 4,
        "name": "Earth Palette",
        "project_id": 2,
        "created_at": "2020-02-05T00:20:49.686Z",
        "updated_at": "2020-02-05T00:20:49.686Z"
    }
```

#### Issues:
- No issues have been closed
- The project board has been updated 

#### Notes:
- When we make a POST for a palette as well as patch, we are still using the format of each color having a key/value pair so the front end will have to format it in that way in order to hit those endpoints. I don't think this will cause an issue but just something to keep in mind.
- The functionality is currently copied and pasted on three endpoints. I was not sure if we could pull this out into a function that gets called within the endpoints in our server.js file? If we are able to do that then that would be a good refactor.

Thanks!
@Garrett-Iannuzzi  